### PR TITLE
fix: replace Coinbase delisted EUROC pairs

### DIFF
--- a/packages/helm-charts/oracle/EUROCEUR.yaml
+++ b/packages/helm-charts/oracle/EUROCEUR.yaml
@@ -16,8 +16,8 @@ oracle:
         {exchange: 'COINBASE', symbol: 'EUROCEUR', toInvert: false}
       ],
       [
-        {exchange: 'COINBASE', symbol: 'EUROCUSD', toInvert: false},
-        {exchange: 'COINBASE', symbol: 'USDTUSD', toInvert: true},
+        {exchange: 'COINBASE', symbol: 'EUROCUSDC', toInvert: false},
+        {exchange: 'COINBASE', symbol: 'USDTUSDC', toInvert: true},
         {exchange: 'COINBASE', symbol: 'USDTEUR', toInvert: false}
       ],
       [

--- a/packages/helm-charts/oracle/EUROCEUR.yaml
+++ b/packages/helm-charts/oracle/EUROCEUR.yaml
@@ -13,9 +13,6 @@ oracle:
   gasPriceMultiplier: 1.5
   priceSources: "[
       [
-        {exchange: 'COINBASE', symbol: 'EUROCEUR', toInvert: false}
-      ],
-      [
         {exchange: 'COINBASE', symbol: 'EUROCUSDC', toInvert: false},
         {exchange: 'COINBASE', symbol: 'USDTUSDC', toInvert: true},
         {exchange: 'COINBASE', symbol: 'USDTEUR', toInvert: false}

--- a/packages/helm-charts/oracle/EUROCXOF.yaml
+++ b/packages/helm-charts/oracle/EUROCXOF.yaml
@@ -27,20 +27,20 @@ oracle:
       ],
 
       [
-        {exchange: 'COINBASE', symbol: 'EUROCUSD', toInvert: false},
-        {exchange: 'COINBASE', symbol: 'USDTUSD', toInvert: true},
+        {exchange: 'COINBASE', symbol: 'EUROCUSDC', toInvert: false},
+        {exchange: 'COINBASE', symbol: 'USDTUSDC', toInvert: true},
         {exchange: 'COINBASE', symbol: 'USDTEUR', toInvert: false},
         {exchange: 'ALPHAVANTAGE', symbol: 'EURXOF', toInvert: false, ignoreVolume: true}
       ],
       [
-        {exchange: 'COINBASE', symbol: 'EUROCUSD', toInvert: false},
-        {exchange: 'COINBASE', symbol: 'USDTUSD', toInvert: true},
+        {exchange: 'COINBASE', symbol: 'EUROCUSDC', toInvert: false},
+        {exchange: 'COINBASE', symbol: 'USDTUSDC', toInvert: true},
         {exchange: 'COINBASE', symbol: 'USDTEUR', toInvert: false},
         {exchange: 'CURRENCYAPI', symbol: 'EURXOF', toInvert: false, ignoreVolume: true}
       ],
       [
-        {exchange: 'COINBASE', symbol: 'EUROCUSD', toInvert: false},
-        {exchange: 'COINBASE', symbol: 'USDTUSD', toInvert: true},
+        {exchange: 'COINBASE', symbol: 'EUROCUSDC', toInvert: false},
+        {exchange: 'COINBASE', symbol: 'USDTUSDC', toInvert: true},
         {exchange: 'COINBASE', symbol: 'USDTEUR', toInvert: false},
         {exchange: 'XIGNITE', symbol: 'EURXOF', toInvert: false, ignoreVolume: true}
       ],

--- a/packages/helm-charts/oracle/EUROCXOF.yaml
+++ b/packages/helm-charts/oracle/EUROCXOF.yaml
@@ -14,19 +14,6 @@ oracle:
   gasPriceMultiplier: 1.5
   priceSources: "[
       [
-        {exchange: 'COINBASE', symbol: 'EUROCEUR', toInvert: false},
-        {exchange: 'ALPHAVANTAGE', symbol: 'EURXOF', toInvert: false, ignoreVolume: true}
-      ],
-      [
-        {exchange: 'COINBASE', symbol: 'EUROCEUR', toInvert: false},
-        {exchange: 'CURRENCYAPI', symbol: 'EURXOF', toInvert: false, ignoreVolume: true}
-      ],
-      [
-        {exchange: 'COINBASE', symbol: 'EUROCEUR', toInvert: false},
-        {exchange: 'XIGNITE', symbol: 'EURXOF', toInvert: false, ignoreVolume: true}
-      ],
-
-      [
         {exchange: 'COINBASE', symbol: 'EUROCUSDC', toInvert: false},
         {exchange: 'COINBASE', symbol: 'USDTUSDC', toInvert: true},
         {exchange: 'COINBASE', symbol: 'USDTEUR', toInvert: false},


### PR DESCRIPTION
### Description

This replaces the delisted EUROCUSD pair on Coinbase with an implicit pairs that goes through EUROCUSDC instead.

### Tested

*Not yet tested*.  I’ll recommend doing the following for both EUROC/EUR and EUROC/XOF (as they were both updated):

1. Run the price source configuration locally. I’d recommend doing two runs:
    1. First run using an existing price source that it’s currently working and doesn’t involve Coinbase’s EUROC/USD. Take note of the price reported
    2. A second run using *only* the price source configuration that involves the new Coinbase EUROC/USDC pair. The price reported should be very close to the previous run.
    3. A final run using all the price sources configuration from the helm charts in the PR. 

### Related issues

- Fixes https://github.com/mento-protocol/mento-general/issues/612